### PR TITLE
Wrapping components in Grid

### DIFF
--- a/src/app/components/DefaultLayout/DefaultLayout.tsx
+++ b/src/app/components/DefaultLayout/DefaultLayout.tsx
@@ -7,7 +7,7 @@ import { env } from "app/config/env"
 export const DefaultLayout: React.FC = () => (
   <>
     <SkipLink href="#main">Direct naar inhoud</SkipLink>
-    <Screen maxWidth="wide">
+    <Screen>
       <Grid>
         <Grid.Cell span="all">
           <Header

--- a/src/app/components/DefaultLayout/DefaultLayout.tsx
+++ b/src/app/components/DefaultLayout/DefaultLayout.tsx
@@ -1,5 +1,5 @@
 import { Outlet } from "react-router-dom"
-import { Header, SkipLink, PageMenu, Screen } from "@amsterdam/design-system-react"
+import { Header, Grid, SkipLink, PageMenu, Screen } from "@amsterdam/design-system-react"
 import { User, NavMenu } from "app/components"
 import { env } from "app/config/env"
 
@@ -8,16 +8,19 @@ export const DefaultLayout: React.FC = () => (
   <>
     <SkipLink href="#main">Direct naar inhoud</SkipLink>
     <Screen maxWidth="wide">
-      <Header 
-        appName={`${ env.VITE_APP_TITLE }`}
-        links={(
-          <PageMenu alignEnd>
-            <li><User/></li>
-          </PageMenu>
-        )}
-      />
-      <NavMenu />
-      <br />
+      <Grid>
+        <Grid.Cell span="all">
+          <Header
+            appName={`${ env.VITE_APP_TITLE }`}
+            links={(
+              <PageMenu alignEnd>
+                <li><User/></li>
+              </PageMenu>
+            )}
+          />
+          <NavMenu />
+        </Grid.Cell>
+      </Grid>
       <main id="main">
         <Outlet />
       </main>

--- a/src/app/components/PageHeading/PageHeading.tsx
+++ b/src/app/components/PageHeading/PageHeading.tsx
@@ -1,4 +1,4 @@
-import { Heading, Icon, IconProps } from "@amsterdam/design-system-react"
+import { Heading, Grid, Icon, IconProps } from "@amsterdam/design-system-react"
 import styled from "styled-components"
 
 type Props = {
@@ -8,10 +8,10 @@ type Props = {
   border?: boolean
 }
 
-type Size = "level-1" | "level-2" | "level-3" | "level-4" | "level-5" | "level-6" 
+type Size = "level-1" | "level-2" | "level-3" | "level-4" | "level-5" | "level-6"
 
 const Wrapper = styled.div<{ $isBorder: boolean }>`
-  display: flex;  
+  display: flex;
   padding-bottom: 8px;
   margin: 24px 0px;
   border-bottom: ${ ({ $isBorder }) => $isBorder ? "1px solid #b4b4b4" : "none" };
@@ -26,14 +26,18 @@ const StyledIcon = styled(Icon)<{ level: number }>`
 `
 
 export const PageHeading: React.FC<Props> = ({ label, level = 2, icon, border = false }) =>  {
-  const size: Size = `level-${ level }` 
+  const size: Size = `level-${ level }`
   return (
-    <Wrapper $isBorder={ border }>
-      { icon && <StyledIcon svg={icon} level={ level }/> }
-      <Heading size={ size } >
-        { label }
-      </Heading>
-    </Wrapper>
+    <Grid paddingVertical="medium">
+      <Grid.Cell span="all">
+        <Wrapper $isBorder={ border }>
+          { icon && <StyledIcon svg={icon} level={ level }/> }
+          <Heading size={ size } >
+            { label }
+          </Heading>
+        </Wrapper>
+      </Grid.Cell>
+    </Grid>
   )
 }
 


### PR DESCRIPTION
I've made some example on how to wrap some page elements in a Grid in order to get padding. The usage of the Grid is explained in our storybook:

- [Page example](https://designsystem.amsterdam/?path=/docs/pages-amsterdam-nl-home-page--docs&globals=theme:Spacious)
- [Grid](https://designsystem.amsterdam/?path=/docs/components-layout-grid--docs&globals=theme:Compact)

To create spacing inside a grid cell using rows or columns you van use these components:

- [Row](https://designsystem.amsterdam/?path=/docs/components-layout-row--docs&globals=theme:Compact)
- [Column](https://designsystem.amsterdam/?path=/docs/components-layout-column--docs&globals=theme:Compact)