### PR TITLE
Move AuthPage to DefaultLayout

### DIFF
--- a/src/app/routing/router.tsx
+++ b/src/app/routing/router.tsx
@@ -64,13 +64,13 @@ const router = createBrowserRouter([
       {
         path: "zaken/:caseId",
         element: <CaseDetailsPage />
+      },
+      {
+        path: "/auth",
+        element: <AuthPage />
       }
     ]
   },
-  {
-    path: "/auth",
-    element: <AuthPage />
-  }
 ])
 
 export default router


### PR DESCRIPTION
Super minor, but small improvement: I'd say the `AuthPage` should be rendered within the `DefaultLayout`. The logging pages are already handled outside of the `RouterProvider`.

---

<img width="1278" height="672" alt="Screenshot 2025-09-15 at 14 52 55" src="https://github.com/user-attachments/assets/5a739e31-d47f-4ac5-a21d-3f2359905bee" />

👇

<img width="1266" height="630" alt="Screenshot 2025-09-15 at 14 52 46" src="https://github.com/user-attachments/assets/a0e52789-54be-4902-ba18-9706c2815307" />
