### PR TITLE
WON-354-na-taak-toevoegen-of-zaak-afsluiten-worden-geen-nieuwe-taken-opgehaald

### DIFF
--- a/src/app/components/DetailsList/DetailsList.tsx
+++ b/src/app/components/DetailsList/DetailsList.tsx
@@ -15,7 +15,7 @@ export const DetailsList: React.FC<Props> = ({ data = [] }) => (
         <DescriptionList.Term key={item?.term}>
           {item?.term}
         </DescriptionList.Term>
-        <DescriptionList.Description>
+        <DescriptionList.Description style={{ maxWidth: "80ch" }}>
           {React.isValidElement(item?.details) ? (
             item.details
           ) : (

--- a/src/app/components/Filters/TaskNameFilter/TaskNameFilter.tsx
+++ b/src/app/components/Filters/TaskNameFilter/TaskNameFilter.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react"
+import React, { useContext, useEffect } from "react"
 import { Field, Label, Select } from "@amsterdam/design-system-react"
 import { ContextValues } from "app/state/context/ValueProvider"
 import { useTaskNames } from "app/state/rest"
@@ -10,6 +10,14 @@ type Props = {
 export const TaskNameFilter: React.FC<Props> = ({ onChangeFilter }) => {
   const { taskName } = useContext(ContextValues)["tasks"]
   const [taskNames] = useTaskNames()
+
+  // If the currently selected taskName is no longer available in options after updating a task
+  // and invalidating the cache, reset it to "Alle taken" to avoid a stale, non-existent filter value.
+  useEffect(() => {
+    if (taskName && Array.isArray(taskNames) && !taskNames.includes(taskName)) {
+      onChangeFilter("")
+    }
+  }, [taskName, taskNames, onChangeFilter])
 
   const onChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     onChangeFilter(e.currentTarget.value)

--- a/src/app/pages/CaseDetailsPage/AddSubtask/SubtaskDialog/SubtaskDialog.tsx
+++ b/src/app/pages/CaseDetailsPage/AddSubtask/SubtaskDialog/SubtaskDialog.tsx
@@ -2,7 +2,8 @@ import { Dialog } from "@amsterdam/design-system-react"
 import { useParams } from "react-router-dom"
 import { Form, FormActionButtons, SelectField } from "app/components/forms"
 import { useCaseProcesses, useCaseProcessesStart } from "app/state/rest"
-import { useMemo } from "react"
+import { useMemo, useContext } from "react"
+import { ApiContext } from "app/state/rest/provider/ApiProvider"
 
 type Props = {
   id: string
@@ -20,6 +21,7 @@ export const SubtaskDialog: React.FC<Props> = ({ id }) => {
   const { caseId } = useParams()
   const [data] = useCaseProcesses(Number(caseId))
   const [, { execPost }] = useCaseProcessesStart(Number(caseId))
+  const { clearCache: clearTasksCache } = useContext(ApiContext)["tasks"]
 
   const options: Option[] = useMemo(() => {
     if (!data) return []
@@ -30,6 +32,7 @@ export const SubtaskDialog: React.FC<Props> = ({ id }) => {
     execPost(variables)
       .then((resp) => {
         console.log("Succes:", resp)
+        clearTasksCache()
       })
       .catch((err) => {
         console.log("Error creating case:", err)

--- a/src/app/pages/CasesPage/CasesFilters.tsx
+++ b/src/app/pages/CasesPage/CasesFilters.tsx
@@ -61,6 +61,16 @@ export const CasesFilters = () => {
         placeholder="Zoek op ID, Excel ID of statutaire naam"
       />
       <PageSizeFilter contextName={CASES} onChangePageSize={onChangePageSize} />
+      <BooleanStatusFilter
+        label="Toon zaken"
+        allLabel="Alle zaken"
+        trueLabel="Gesloten zaken"
+        falseLabel="Open zaken"
+        onChangeFilter={(value: string) =>
+          onChangeFilter("isClosedFilter", value)
+        }
+        value={isClosedFilter}
+      />
       <StatusFilter
         contextName={CASES}
         onChangeFilter={(value: string) => onChangeFilter("status", value)}
@@ -69,14 +79,14 @@ export const CasesFilters = () => {
         contextName={CASES}
         onChangeFilter={(value: string) => onChangeFilter("district", value)}
       />
-      <NeighborhoodFilter
-        contextName={CASES}
-        onChangeFilter={(value: string) =>
-          onChangeFilter("neighborhood", value)
-        }
-      />
       {showAllFilters ? (
         <>
+          <NeighborhoodFilter
+            contextName={CASES}
+            onChangeFilter={(value: string) =>
+              onChangeFilter("neighborhood", value)
+            }
+          />
           <ApplicationTypeFilter
             contextName={CASES}
             onChangeFilter={(value: string) =>
@@ -116,16 +126,6 @@ export const CasesFilters = () => {
             onChangeFilter={(value: string) =>
               onChangeFilter("createdRangeBefore", value)
             }
-          />
-          <BooleanStatusFilter
-            label="Toon zaken"
-            allLabel="Alle zaken"
-            trueLabel="Gesloten zaken"
-            falseLabel="Open zaken"
-            onChangeFilter={(value: string) =>
-              onChangeFilter("isClosedFilter", value)
-            }
-            value={isClosedFilter}
           />
           <DateFilter
             value={endDateRangeAfter}

--- a/src/app/state/rest/hooks/useApiRequest.ts
+++ b/src/app/state/rest/hooks/useApiRequest.ts
@@ -47,7 +47,6 @@ const useApiRequest = <Schema, Payload = Partial<Schema>>({
     setCacheItem,
     updateCacheItem,
     addErrorToCacheItem,
-    clearCache,
     pushRequestInQueue,
     isRequestPendingInQueue
   } = apiContext[groupName]


### PR DESCRIPTION
- Adds a sensible `max-width` do `DetailList` descriptions (e.g. vve names), so PDF button doesn't drop;
- Moves `Toon zaken` filter before `Status`, because status shows values which won't work without setting the `Toon zaken` to `Alle zaken` (by default it's only `Open zaken`, and it's pretty tucked away, and therefore filtering on `Afgesloten` or `Afgewezen` never returned any results);
- Invalidates `tasks` API cache contexts when completing a task, or both `cases` and `tasks` when closing a case, so the the task/case overview fetches new data which reflects what just happened (instead of having to 'hard refresh' your browser);
- Updates edge case `Open taken` filter when you just completed a task and had filtered on that, and that task type is removed from the listing and therefore not a valid filter anymore...

---

<img width="1519" height="842" alt="Screenshot 2025-09-16 at 11 08 19" src="https://github.com/user-attachments/assets/e4abe1b1-be71-4b58-8005-08f3bcf9562d" />

<img width="588" height="385" alt="Screenshot 2025-09-16 at 11 08 09" src="https://github.com/user-attachments/assets/6056ec43-a5af-4387-ac6e-c79a32978d88" />
