### PR TITLE
feat: add local schema generation script and update Swagger schema types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -309,13 +309,13 @@
       }
     },
     "node_modules/@bpmn-io/diagram-js-ui": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.3.tgz",
-      "integrity": "sha512-OGyjZKvGK8tHSZ0l7RfeKhilGoOGtFDcoqSGYkX0uhFlo99OVZ9Jn1K7TJGzcE9BdKwvA5Y5kGqHEhdTxHvFfw==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.4.tgz",
+      "integrity": "sha512-I678ZGtoH7z7FgzFhzzppM9ThsJ3Lh83kW3GjhjG3xyYciIPYHMaHK1MABP8F69H9pFZpViM6t4qUo8dwrVz0w==",
       "license": "MIT",
       "dependencies": {
         "htm": "^3.1.1",
-        "preact": "^10.11.2"
+        "preact": "^10.29.2"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -398,9 +398,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
-      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.7.tgz",
+      "integrity": "sha512-CmjJFQTFQx/U/xNJhSjCQ0ilpesPmNQ8+eOUeM/+kDOVW33qsIjeOXc27vrQDdWVkf83ZSWwtg7kXSUvKDJ8cQ==",
       "dev": true,
       "funding": [
         {
@@ -449,9 +449,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
-      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
       "dev": true,
       "funding": [
         {
@@ -970,13 +970,13 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -1456,9 +1456,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1491,9 +1491,9 @@
       "optional": true
     },
     "node_modules/@types/react": {
-      "version": "19.2.16",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
-      "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1534,17 +1534,17 @@
       "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.1.tgz",
-      "integrity": "sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.0.tgz",
+      "integrity": "sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.60.1",
-        "@typescript-eslint/type-utils": "8.60.1",
-        "@typescript-eslint/utils": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1",
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/type-utils": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1557,7 +1557,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.60.1",
+        "@typescript-eslint/parser": "^8.61.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -1573,16 +1573,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.1.tgz",
-      "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.0.tgz",
+      "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.60.1",
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/typescript-estree": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1",
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1598,14 +1598,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.1.tgz",
-      "integrity": "sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.0.tgz",
+      "integrity": "sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.60.1",
-        "@typescript-eslint/types": "^8.60.1",
+        "@typescript-eslint/tsconfig-utils": "^8.61.0",
+        "@typescript-eslint/types": "^8.61.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1620,14 +1620,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz",
-      "integrity": "sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.0.tgz",
+      "integrity": "sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1"
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1638,9 +1638,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.1.tgz",
-      "integrity": "sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz",
+      "integrity": "sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1655,15 +1655,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.1.tgz",
-      "integrity": "sha512-sdwTrpjosW7ANQYJ39ZBF1ZyEMEGVB2UsikrserVM/30a/F1dTLnu9bGxEdosugyu5caigjLrR2qiD11asjI1A==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.0.tgz",
+      "integrity": "sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/typescript-estree": "8.60.1",
-        "@typescript-eslint/utils": "8.60.1",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1680,9 +1680,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
-      "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
+      "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1694,16 +1694,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.1.tgz",
-      "integrity": "sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz",
+      "integrity": "sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.60.1",
-        "@typescript-eslint/tsconfig-utils": "8.60.1",
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1",
+        "@typescript-eslint/project-service": "8.61.0",
+        "@typescript-eslint/tsconfig-utils": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1722,16 +1722,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.1.tgz",
-      "integrity": "sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.0.tgz",
+      "integrity": "sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.60.1",
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/typescript-estree": "8.60.1"
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1746,13 +1746,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.1.tgz",
-      "integrity": "sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz",
+      "integrity": "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/types": "8.61.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1789,16 +1789,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
-      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1807,13 +1807,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
-      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.8",
+        "@vitest/spy": "4.1.9",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1834,9 +1834,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
-      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1847,13 +1847,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
-      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.8",
+        "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1861,14 +1861,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
-      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1877,9 +1877,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
-      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1887,13 +1887,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
-      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
+        "@vitest/pretty-format": "4.1.9",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1909,9 +1909,9 @@
       "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -2157,9 +2157,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -2273,14 +2273,14 @@
       "license": "MIT"
     },
     "node_modules/bpmn-js": {
-      "version": "18.16.1",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.16.1.tgz",
-      "integrity": "sha512-qdJp/1JbKY3JtqB2L7LF4VEJtVlbl9AGkvyUjzJlBJ8jURNNTx+22OdrZMVNPxaGOjW+nuHK38ObFCmMCp/Kcg==",
+      "version": "18.18.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.18.0.tgz",
+      "integrity": "sha512-3pTiqc5M+CRtXCvBjRBFEewqNKDnx0ytuCLucvMRfdhes/EuVr4memcsi6ql+q/1RUbycOL9MyfNcgrwSfnA1w==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "bpmn-moddle": "^10.0.0",
-        "diagram-js": "^15.14.0",
-        "diagram-js-direct-editing": "^3.3.0",
+        "diagram-js": "^15.17.0",
+        "diagram-js-direct-editing": "^3.4.0",
         "ids": "^3.0.2",
         "inherits-browser": "^0.1.0",
         "min-dash": "^5.0.0",
@@ -2755,12 +2755,12 @@
       }
     },
     "node_modules/diagram-js": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.14.0.tgz",
-      "integrity": "sha512-xXIKBgK9qC5YIfdUs0Qx+rSlz3DNGMtYxx+pRK+U8eVBD184eZnLCu6KVzaZXXyyC5YRirQayorCVI55Ulhzvg==",
+      "version": "15.17.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.17.0.tgz",
+      "integrity": "sha512-wOlnfzd7MmcUMwIpJiCiFScQ04hQMx4Ribir0ky4cfNgzwr7V1dhi7MdFuLyaMdseglMkBU7YYoqmzCDR8+JCw==",
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/diagram-js-ui": "^0.2.3",
+        "@bpmn-io/diagram-js-ui": "^0.2.4",
         "clsx": "^2.1.1",
         "didi": "^11.0.0",
         "inherits-browser": "^0.1.0",
@@ -2839,9 +2839,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
-      "integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
+      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true,
       "optionalDependencies": {
@@ -3114,11 +3114,14 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.1.tgz",
-      "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
+      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3474,16 +3477,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -4970,15 +4973,18 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/oidc-client-ts": {
       "version": "3.5.0",
@@ -5266,9 +5272,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5304,9 +5310,9 @@
       "license": "MIT"
     },
     "node_modules/proj4": {
-      "version": "2.20.8",
-      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.20.8.tgz",
-      "integrity": "sha512-1C8sfT4xY4PAPwk0MroFBTGF4R4bzDXdmPQTGYVLsoNssrZ9odzObxS2dTeGBty8jW8KO7h16C1Hs2JP+ctfFw==",
+      "version": "2.20.9",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.20.9.tgz",
+      "integrity": "sha512-GLBGqXaTcdWnppre3o1sMmy4DcMGSGq/ng+9k2MTNddarRK6SveINqlqYzi3xEXuy06ljY1TTrC6H9C4f360IQ==",
       "license": "MIT",
       "dependencies": {
         "mgrs": "1.0.0",
@@ -5314,6 +5320,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ahocevar"
+      },
+      "peerDependencies": {
+        "geotiff": "*"
+      },
+      "peerDependenciesMeta": {
+        "geotiff": {
+          "optional": true
+        }
       }
     },
     "node_modules/prop-types": {
@@ -5399,9 +5413,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.77.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.77.0.tgz",
-      "integrity": "sha512-Sslh9YDYc0GDlWT/lxasnIduNo4v3yyvqRGvmGKUre5AFjDs/HV9/OafHGD8d+sB2yoL4UIL9L8X9i0WlZZebg==",
+      "version": "7.79.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.79.0.tgz",
+      "integrity": "sha512-mhYp/MTmXvzYX6AJcJVko0rktoIhhmRnEouObj4wF5i/tCttgJvnp1+9wRkpITZjDTqpo4IOSJqu0dBlPlV/Lw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -5436,9 +5450,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -5458,12 +5472,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
-      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
+      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.16.0"
+        "react-router": "7.17.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -5774,9 +5788,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5822,14 +5836,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -6350,16 +6364,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.1.tgz",
-      "integrity": "sha512-6m5hkkRAp8lKvhVpcprAIn5KkehQEh+47oHH2VGnExEh7dhNxXlg6GPAOIu6TxbVQxhebrJDvjl3020ooiWCMA==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.0.tgz",
+      "integrity": "sha512-8y31Rd0eGTrDKqhy6vT0HtzhN+YLjQizwX3aA3hPXP/ynSfnrBXcQY5IzsP9/DM7+klX4IUncZZjkchP0z+rUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.60.1",
-        "@typescript-eslint/parser": "8.60.1",
-        "@typescript-eslint/typescript-estree": "8.60.1",
-        "@typescript-eslint/utils": "8.60.1"
+        "@typescript-eslint/eslint-plugin": "8.61.0",
+        "@typescript-eslint/parser": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6374,9 +6388,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.0.tgz",
-      "integrity": "sha512-+t2Z/GwkZQDtu00813aP66ygViGtPHKhhoFZpQKpKrE+9jIgES+Zw+mFNaDWOVRKiuJjuqKHzD3B1sfGg8+ZOQ==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6572,19 +6586,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
-      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.8",
-        "@vitest/mocker": "4.1.8",
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/runner": "4.1.8",
-        "@vitest/snapshot": "4.1.8",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -6612,12 +6626,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.8",
-        "@vitest/browser-preview": "4.1.8",
-        "@vitest/browser-webdriverio": "4.1.8",
-        "@vitest/coverage-istanbul": "4.1.8",
-        "@vitest/coverage-v8": "4.1.8",
-        "@vitest/ui": "4.1.8",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "prettier": "prettier --check src",
     "format": "prettier --write src",
     "swagger:generate-schema": "TS_NODE_PROJECT=./scripts/tsconfig.json ts-node scripts/src/generateSwaggerSchema.ts",
+    "swagger:generate-schema:local": "VITE_SWAGGER_SCHEMA_URL=http://localhost:8081/api/schema/?format=json TS_NODE_PROJECT=./scripts/tsconfig.json ts-node scripts/src/generateSwaggerSchema.ts",
     "test": "vitest",
     "preview": "vite preview"
   },

--- a/scripts/src/generateSwaggerSchema.ts
+++ b/scripts/src/generateSwaggerSchema.ts
@@ -4,7 +4,7 @@ import { config } from "dotenv"
 config({ path: ".env.local" })
 
 // To run against another backend than the default, add a `.env.local` file with the following content:
-// VITE_SWAGGER_SCHEMA_URL=http://localhost:8081/api/schema/?format=json
+// const VITE_SWAGGER_SCHEMA_URL=http://localhost:8081/api/schema/?format=json
 const url = process.env.VITE_SWAGGER_SCHEMA_URL || "https://acc.api.zwd.amsterdam.nl/api/schema/?format=json"
 
 console.log(`👉 Generating schema from \`${ url }\``)

--- a/src/__generated__/apiSchema.d.ts
+++ b/src/__generated__/apiSchema.d.ts
@@ -17,8 +17,10 @@ declare namespace Components {
         /**
          * * `Energieadvies` - ENERGY_ADVICE
          * * `Haalbaarheidsonderzoek` - HBO
+         * * `Energieadvies (OUD)` - OLD_ENERGY_ADVICE
+         * * `Zon-Advies (OUD)` - OLD_SOLAR_ADVICE
          */
-        export type AdviceTypeEnum = "Energieadvies" | "Haalbaarheidsonderzoek";
+        export type AdviceTypeEnum = "Energieadvies" | "Haalbaarheidsonderzoek" | "Energieadvies (OUD)" | "Zon-Advies (OUD)";
         export interface Apartment {
             straatnaam?: string | null;
             huisnummer?: number | null;
@@ -47,6 +49,8 @@ declare namespace Components {
             advice_type?: null & (/**
              * * `Energieadvies` - ENERGY_ADVICE
              * * `Haalbaarheidsonderzoek` - HBO
+             * * `Energieadvies (OUD)` - OLD_ENERGY_ADVICE
+             * * `Zon-Advies (OUD)` - OLD_SOLAR_ADVICE
              */
             AdviceTypeEnum | BlankEnum | NullEnum);
             application_type?: /**
@@ -91,6 +95,8 @@ declare namespace Components {
             advice_type?: null & (/**
              * * `Energieadvies` - ENERGY_ADVICE
              * * `Haalbaarheidsonderzoek` - HBO
+             * * `Energieadvies (OUD)` - OLD_ENERGY_ADVICE
+             * * `Zon-Advies (OUD)` - OLD_SOLAR_ADVICE
              */
             AdviceTypeEnum | BlankEnum | NullEnum);
             application_type?: /**
@@ -158,6 +164,8 @@ declare namespace Components {
             advice_type?: null & (/**
              * * `Energieadvies` - ENERGY_ADVICE
              * * `Haalbaarheidsonderzoek` - HBO
+             * * `Energieadvies (OUD)` - OLD_ENERGY_ADVICE
+             * * `Zon-Advies (OUD)` - OLD_SOLAR_ADVICE
              */
             AdviceTypeEnum | BlankEnum | NullEnum);
             advisor: string;
@@ -267,6 +275,9 @@ declare namespace Components {
             owners?: Owner[];
             wijk: string;
             zip_code?: string | null;
+            letter_count: string;
+            advice_cases_count: string;
+            activationteam_cases_count: string;
         }
         export interface HomeownerAssociationCommunicationNote {
             id: number;
@@ -332,6 +343,8 @@ declare namespace Components {
             advice_type?: null & (/**
              * * `Energieadvies` - ENERGY_ADVICE
              * * `Haalbaarheidsonderzoek` - HBO
+             * * `Energieadvies (OUD)` - OLD_ENERGY_ADVICE
+             * * `Zon-Advies (OUD)` - OLD_SOLAR_ADVICE
              */
             AdviceTypeEnum | BlankEnum | NullEnum);
             application_type?: /**
@@ -467,12 +480,12 @@ declare namespace Components {
             count: number;
             /**
              * example:
-             * http://api.example.org/accounts/?offset=400&limit=100
+             * http://api.example.org/accounts/?page=4
              */
             next?: string | null; // uri
             /**
              * example:
-             * http://api.example.org/accounts/?offset=200&limit=100
+             * http://api.example.org/accounts/?page=2
              */
             previous?: string | null; // uri
             results: HomeownerAssociation[];
@@ -537,6 +550,23 @@ declare namespace Components {
         }
         export interface StartWorkflow {
             workflow_option_id: number;
+        }
+        export interface SubsidyItem {
+            id: number;
+            dossiernummer: string;
+            aanvrager: string;
+            regelingnaam: string;
+            beleidsterrein?: string | null;
+            organisatieonderdeel?: string | null;
+            projectnaam?: string | null;
+            typePeriodiciteit?: string | null;
+            bedragAangevraagd?: string | null; // decimal ^-?\d{0,10}(?:\.\d{0,2})?$
+            bedragVerleend?: string | null; // decimal ^-?\d{0,10}(?:\.\d{0,2})?$
+            publicatiedatumVerleningsbesluit?: string | null; // date
+            bedragVastgesteld?: string | null; // decimal ^-?\d{0,10}(?:\.\d{0,2})?$
+            publicatiedatumVaststellingsbesluit?: string | null; // date
+            subsidiejaar?: number | null;
+            datumOverzicht?: string | null; // date
         }
         export interface Wijk {
             id: number;
@@ -706,7 +736,7 @@ declare namespace Paths {
     }
     namespace CasesAdvisorsList {
         namespace Parameters {
-            export type AdviceType = "Energieadvies" | "Haalbaarheidsonderzoek";
+            export type AdviceType = "Energieadvies" | "Energieadvies (OUD)" | "Haalbaarheidsonderzoek" | "Zon-Advies (OUD)";
             export type Advisor = number[];
             export type ApplicationType = "Activatieteam" | "Advies";
             export type Closed = boolean;
@@ -835,7 +865,7 @@ declare namespace Paths {
     }
     namespace CasesList {
         namespace Parameters {
-            export type AdviceType = "Energieadvies" | "Haalbaarheidsonderzoek";
+            export type AdviceType = "Energieadvies" | "Energieadvies (OUD)" | "Haalbaarheidsonderzoek" | "Zon-Advies (OUD)";
             export type Advisor = number[];
             export type ApplicationType = "Activatieteam" | "Advies";
             export type Closed = boolean;
@@ -880,7 +910,7 @@ declare namespace Paths {
     }
     namespace CasesProcessesList {
         namespace Parameters {
-            export type AdviceType = "Energieadvies" | "Haalbaarheidsonderzoek";
+            export type AdviceType = "Energieadvies" | "Energieadvies (OUD)" | "Haalbaarheidsonderzoek" | "Zon-Advies (OUD)";
             export type Advisor = number[];
             export type ApplicationType = "Activatieteam" | "Advies";
             export type Closed = boolean;
@@ -1128,12 +1158,26 @@ declare namespace Paths {
     }
     namespace HomeownerAssociationList {
         namespace Parameters {
-            export type Limit = number;
-            export type Offset = number;
+            export type CourseParticipantCount = number;
+            export type District = string[];
+            export type IsSmallHoa = boolean;
+            export type LetterCount = number;
+            export type Neighborhood = string[];
+            export type Ordering = string;
+            export type Page = number;
+            export type PageSize = number;
+            export type Search = string;
         }
         export interface QueryParameters {
-            limit?: Parameters.Limit;
-            offset?: Parameters.Offset;
+            course_participant_count?: Parameters.CourseParticipantCount;
+            district?: Parameters.District;
+            is_small_hoa?: Parameters.IsSmallHoa;
+            letter_count?: Parameters.LetterCount;
+            neighborhood?: Parameters.Neighborhood;
+            ordering?: Parameters.Ordering;
+            page?: Parameters.Page;
+            page_size?: Parameters.PageSize;
+            search?: Parameters.Search;
         }
         namespace Responses {
             export type $200 = Components.Schemas.PaginatedHomeownerAssociationList;
@@ -1151,12 +1195,6 @@ declare namespace Paths {
             export type $200 = Components.Schemas.HomeownerAssociationUpdate;
         }
     }
-    namespace HomeownerAssociationPriorityZipcodeCreate {
-        export type RequestBody = Components.Schemas.HomeownerAssociation;
-        namespace Responses {
-            export type $200 = Components.Schemas.HomeownerAssociation;
-        }
-    }
     namespace HomeownerAssociationRetrieve {
         namespace Parameters {
             export type Id = number;
@@ -1171,6 +1209,19 @@ declare namespace Paths {
     namespace HomeownerAssociationSearchRetrieve {
         namespace Responses {
             export type $200 = Components.Schemas.HomeownerAssociation;
+        }
+    }
+    namespace HomeownerAssociationSubsidyList {
+        namespace Parameters {
+            export type Id = number;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export type $200 = Components.Schemas.SubsidyItem[];
+            export interface $503 {
+            }
         }
     }
     namespace HomeownerAssociationUpdate {
@@ -1211,7 +1262,7 @@ declare namespace Paths {
     }
     namespace TasksList {
         namespace Parameters {
-            export type AdviceType = "Energieadvies" | "Haalbaarheidsonderzoek";
+            export type AdviceType = "Energieadvies" | "Energieadvies (OUD)" | "Haalbaarheidsonderzoek" | "Zon-Advies (OUD)";
             export type Advisor = string[];
             export type ApplicationType = "Activatieteam" | "Advies";
             export type District = string[];

--- a/src/app/components/PageHeading/PageHeading.tsx
+++ b/src/app/components/PageHeading/PageHeading.tsx
@@ -14,12 +14,7 @@ type Props = {
   backLinkLabel?: string
 }
 
-type Size =
-  | "level-1"
-  | "level-2"
-  | "level-3"
-  | "level-4"
-  | "level-5"
+type Size = "level-1" | "level-2" | "level-3" | "level-4" | "level-5"
 
 export const PageHeading: React.FC<Props> = ({
   label,

--- a/src/app/components/forms/Form/Form.tsx
+++ b/src/app/components/forms/Form/Form.tsx
@@ -52,10 +52,7 @@ export const Form = <T extends FieldValues>({
 
   return (
     <>
-      <Grid
-        paddingBottom="x-large"
-        style={{ paddingLeft: 0 }}
-      >
+      <Grid paddingBottom="x-large" style={{ paddingLeft: 0 }}>
         <Grid.Cell span={formGrid}>
           <form
             className="ams-gap-m"

--- a/src/app/pages/AddressPage/AddOrEditHoaContactDialog/AddOrEditHoaContactDialog.tsx
+++ b/src/app/pages/AddressPage/AddOrEditHoaContactDialog/AddOrEditHoaContactDialog.tsx
@@ -19,10 +19,12 @@ import {
   validationPhone
 } from "app/utils/validation"
 
-export enum FormMode {
-  ADD = "add",
-  EDIT = "edit"
-}
+export const FormMode = {
+  ADD: "add",
+  EDIT: "edit"
+} as const
+
+export type FormMode = (typeof FormMode)[keyof typeof FormMode]
 
 type Contact = Components.Schemas.Contact
 

--- a/src/app/pages/AddressPage/AddressPage.tsx
+++ b/src/app/pages/AddressPage/AddressPage.tsx
@@ -13,7 +13,8 @@ import {
 } from "@amsterdam/design-system-react"
 import {
   useHomeownerAssociation,
-  useHomeownerAssociationByBagId
+  useHomeownerAssociationByBagId,
+  useHomeownerAssociationSubsidy
 } from "app/state/rest"
 import HoaCases from "./HoaCases"
 import HoaOwners from "./HoaOwners"
@@ -24,11 +25,13 @@ import Communication from "./Communication"
 import { useURLState } from "app/hooks"
 import {
   CertificateIcon,
+  EuroCoinsIcon,
   FolderIcon,
   PencilIcon,
   PersonIcon,
   MegaphoneIcon
 } from "@amsterdam/design-system-react-icons"
+import Subsidy from "./Subsidy/Subsidy"
 
 type TabHeaderProps = {
   label: string
@@ -50,11 +53,58 @@ export const AddressPage: React.FC = () => {
   const [dataByBagId, { isBusy }] = useHomeownerAssociationByBagId(bagId)
   const [dataByHoaId, { isBusy: isLoading }] =
     useHomeownerAssociation(hoaIdNumber)
+  const hoa = bagId ? dataByBagId : dataByHoaId
+  const [dataSubsidy] = useHomeownerAssociationSubsidy(hoa?.id)
   const [activeTab, setActiveTab] = useURLState("tab", "zaken")
 
   const hasId = bagId || hoaId
   const loading = isBusy || isLoading
-  const hoa = bagId ? dataByBagId : dataByHoaId
+  const hasSubsidies = Array.isArray(dataSubsidy) && dataSubsidy.length > 0
+
+  const tabs = hoa?.id
+    ? [
+        {
+          id: "zaken",
+          icon: FolderIcon,
+          label: "Zaken",
+          panel: <HoaCases hoaId={hoa.id} />
+        },
+        {
+          id: "contactpersonen",
+          icon: PersonIcon,
+          label: "Contactpersonen",
+          panel: <HoaContacts hoaId={hoa.id} />
+        },
+        {
+          id: "eigenaren",
+          icon: CertificateIcon,
+          label: "Eigenaren",
+          panel: <HoaOwners hoa={hoa} />
+        },
+        {
+          id: "communicatie",
+          icon: MegaphoneIcon,
+          label: "Communicatie",
+          panel: <Communication hoaId={hoa.id} />
+        },
+        {
+          id: "aantekeningen",
+          icon: PencilIcon,
+          label: "Aantekeningen",
+          panel: <Annotation hoaId={hoa.id} />
+        },
+        ...(hasSubsidies
+          ? [
+              {
+                id: "subsidies",
+                icon: EuroCoinsIcon,
+                label: `Subsidies (${dataSubsidy.length})`,
+                panel: <Subsidy data={dataSubsidy} />
+              }
+            ]
+          : [])
+      ]
+    : []
 
   return (
     <PageGrid>
@@ -98,37 +148,17 @@ export const AddressPage: React.FC = () => {
               style={{ marginTop: "2rem" }}
             >
               <Tabs.List>
-                <Tabs.Button aria-controls="zaken">
-                  <TabHeader svg={FolderIcon} label="Zaken" />
-                </Tabs.Button>
-                <Tabs.Button aria-controls="contactpersonen">
-                  <TabHeader svg={PersonIcon} label="Contactpersonen" />
-                </Tabs.Button>
-                <Tabs.Button aria-controls="eigenaren">
-                  <TabHeader svg={CertificateIcon} label="Eigenaren" />
-                </Tabs.Button>
-                <Tabs.Button aria-controls="communicatie">
-                  <TabHeader svg={MegaphoneIcon} label="Communicatie" />
-                </Tabs.Button>
-                <Tabs.Button aria-controls="aantekeningen">
-                  <TabHeader svg={PencilIcon} label="Aantekeningen" />
-                </Tabs.Button>
+                {tabs.map((tab) => (
+                  <Tabs.Button key={tab.id} aria-controls={tab.id}>
+                    <TabHeader svg={tab.icon} label={tab.label} />
+                  </Tabs.Button>
+                ))}
               </Tabs.List>
-              <Tabs.Panel id="zaken">
-                <HoaCases hoaId={hoa.id} />
-              </Tabs.Panel>
-              <Tabs.Panel id="contactpersonen">
-                <HoaContacts hoaId={hoa.id} />
-              </Tabs.Panel>
-              <Tabs.Panel id="eigenaren">
-                <HoaOwners hoa={hoa} />
-              </Tabs.Panel>
-              <Tabs.Panel id="communicatie">
-                <Communication hoaId={hoa.id} />
-              </Tabs.Panel>
-              <Tabs.Panel id="aantekeningen">
-                <Annotation hoaId={hoa.id} />
-              </Tabs.Panel>
+              {tabs.map((tab) => (
+                <Tabs.Panel key={tab.id} id={tab.id}>
+                  {tab.panel}
+                </Tabs.Panel>
+              ))}
             </Tabs>
           )}
         </>

--- a/src/app/pages/AddressPage/Subsidy/Subsidy.tsx
+++ b/src/app/pages/AddressPage/Subsidy/Subsidy.tsx
@@ -1,0 +1,87 @@
+import React from "react"
+import { Descriptions } from "app/components"
+import { Heading } from "@amsterdam/design-system-react"
+
+type Props = {
+  data: Components.Schemas.SubsidyItem[]
+}
+
+const formatCurrency = (value?: string | null): string => {
+  if (value === null || value === undefined) return "-"
+  const number = parseFloat(value)
+  if (isNaN(number)) return "-"
+  return new Intl.NumberFormat("nl-NL", {
+    style: "currency",
+    currency: "EUR"
+  }).format(number)
+}
+
+const formatDate = (value?: string | null): string => {
+  if (!value) return "-"
+  return new Date(value).toLocaleDateString("nl-NL")
+}
+
+const formatValue = (value?: string | number | null): string => {
+  if (value === null || value === undefined || value === "") return "-"
+  return String(value)
+}
+
+const Subsidy: React.FC<Props> = ({ data }) => {
+  if (!data || data.length === 0) {
+    return <p>Geen subsidieaanvraag bekend</p>
+  }
+
+  return (
+    <div style={{ marginTop: "1rem" }}>
+      {data.map((item) => {
+        const items = [
+          { label: "Aanvrager", value: formatValue(item.aanvrager) },
+          { label: "Regeling", value: formatValue(item.regelingnaam) },
+          { label: "Beleidsterrein", value: formatValue(item.beleidsterrein) },
+          {
+            label: "Organisatieonderdeel",
+            value: formatValue(item.organisatieonderdeel)
+          },
+          { label: "Projectnaam", value: formatValue(item.projectnaam) },
+          {
+            label: "Periodiciteit",
+            value: formatValue(item.typePeriodiciteit)
+          },
+          { label: "Subsidiejaar", value: formatValue(item.subsidiejaar) },
+          {
+            label: "Bedrag aangevraagd",
+            value: formatCurrency(item.bedragAangevraagd)
+          },
+          {
+            label: "Bedrag verleend",
+            value: formatCurrency(item.bedragVerleend)
+          },
+          {
+            label: "Datum verleningsbesluit",
+            value: formatDate(item.publicatiedatumVerleningsbesluit)
+          },
+          {
+            label: "Bedrag vastgesteld",
+            value: formatCurrency(item.bedragVastgesteld)
+          },
+          {
+            label: "Datum vaststellingsbesluit",
+            value: formatDate(item.publicatiedatumVaststellingsbesluit)
+          },
+          { label: "Datum overzicht", value: formatDate(item.datumOverzicht) }
+        ]
+
+        return (
+          <div key={item.id} style={{ marginBottom: "3rem" }}>
+            <Heading size="level-3" level={3} style={{ marginBottom: "1rem" }}>
+              Subsidieaanvraag {item.dossiernummer}
+            </Heading>
+            <Descriptions items={items} />
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export default Subsidy

--- a/src/app/pages/CaseCreatePage/formOptions.ts
+++ b/src/app/pages/CaseCreatePage/formOptions.ts
@@ -14,14 +14,10 @@ export const ACTIVATIETEAM_TYPES = {
 }
 
 export const ACTIVATIETEAM_SUBJECTS = {
-  ADVIES_PRESENTATIE:
-    "De adviseur presenteert het verduurzamingsadvies",
-  OPTIE_KEUZE:
-    "We kiezen een scenario om te verduurzamen",
-  UITVOERINGS_BESLUIT:
-    "We geven opdracht om de verduurzaming uit te voeren",
-  FINANCIEEL_BESLUIT:
-    "We beslissen hoe we de verduurzaming financieren",
+  ADVIES_PRESENTATIE: "De adviseur presenteert het verduurzamingsadvies",
+  OPTIE_KEUZE: "We kiezen een scenario om te verduurzamen",
+  UITVOERINGS_BESLUIT: "We geven opdracht om de verduurzaming uit te voeren",
+  FINANCIEEL_BESLUIT: "We beslissen hoe we de verduurzaming financieren",
   ANDERS: "Iets anders, namelijk:"
 }
 

--- a/src/app/state/rest/hoa.ts
+++ b/src/app/state/rest/hoa.ts
@@ -83,6 +83,21 @@ export const useHomeownerAssociationCases = (
   })
 }
 
+export const useHomeownerAssociationSubsidy = (
+  id?: Components.Schemas.HomeownerAssociation["id"],
+  options?: Options
+) => {
+  const handleError = useErrorHandler()
+  return useApiRequest<Components.Schemas.SubsidyItem[]>({
+    ...options,
+    url: `${makeApiUrl("homeowner-association", id, "subsidy")}`,
+    lazy: id === undefined,
+    groupName: "hoas",
+    handleError,
+    isProtected: true
+  })
+}
+
 export const useHomeownerAssociationSearch = (
   searchString?: string,
   options?: Options

--- a/src/app/styles/design-system-overrides.css
+++ b/src/app/styles/design-system-overrides.css
@@ -1,7 +1,7 @@
 /* This file is used to override the default design system styles */
 :root {
   --ams-page-max-inline-size: 100rem;
-  --ams-color-background-body: #fff;
+  --ams-page-background-color: #fff;
 }
 
 body,


### PR DESCRIPTION
- Added a new npm script for generating Swagger schema locally.
- Updated `generateSwaggerSchema.ts` to reflect changes in environment variable handling.
- Extended `AdviceTypeEnum` in `apiSchema.d.ts` to include new advice types.
- Introduced a new `SubsidyItem` interface in `apiSchema.d.ts` for handling subsidy data.
- Enhanced `AddressPage` to include a new `Subsidy` component displaying subsidy information.
- Refactored `FormMode` to use a constant object instead of an enum.
- Updated various components and pages for improved code readability and structure.
- Adjusted CSS variable for background color in design system overrides.